### PR TITLE
Implement on_game_load function for mods

### DIFF
--- a/API.md
+++ b/API.md
@@ -477,6 +477,74 @@ chaudloader.util: {
 
 See [chaudloader/src/mods/lua/lib/chaudloader/util.lua](chaudloader/src/mods/lua/lib/chaudloader/util.lua) for functions available in this namespace.
 
+## DLL mod functions
+
+### `on_game_load`
+
+This function is called when a Battle Network game is loaded. It is called after the ROM is loaded and memory is initialized, but before the game has been run.
+
+The function should have the following signature:
+
+```c
+__declspec(dllexport) void on_game_load(int game, GBAState* gba_state) {
+    // Do all your logic here.
+}
+```
+`game`: This is the BN game being loaded.  It can contain the values:
+* Battle Network 1 = 0
+* Battle Network 2 = 2
+* Battle Network 3 White = 3
+* Battle Network 3 Blue = 4
+* Battle Network 4 Red Sun = 5
+* Battle Network 4 Blue Moon = 6
+* Battle Network 5 Team ProtoMan = 7
+* Battle Network 5 Team Colonel = 8
+* Battle Network 6 Cybeast Gregar = 9
+* Battle Network 6 Cybeast Falzar = 10
+
+A basic enum for this is:
+
+```c
+enum class MMBNGame : int {
+    BN1 = 0,
+    Unused,
+    BN2,
+    BN3_White,
+    BN3_Blue,
+    BN4_RedSun,
+    BN4_BlueMoon,
+    BN5_ProtoMan,
+    BN5_Colonel,
+    BN6_Gregar,
+    BN6_Falzar,
+};
+```
+`gba_state`: Pointer to the GBA state struct. A basic definition is:
+```c
+struct GBAState {
+    uint32_t r0;
+    uint32_t r1;
+    uint32_t r2;
+    uint32_t r3;
+    uint32_t r4;
+    uint32_t r5;
+    uint32_t r6;
+    uint32_t r7;
+    uint32_t r8;
+    uint32_t r9;
+    uint32_t r10;
+    uint32_t r11;
+    uint32_t r12;
+    uint32_t r13;
+    uint32_t r14;
+    uint32_t r15;
+    uint32_t cpuFlags;
+    uint32_t flagsImplicitUpdate;
+    uint8_t* memory;
+}
+```
+
+
 ## Deprecated API
 
 ### Compatibility shims

--- a/chaudloader/src/hooks/stage0.rs
+++ b/chaudloader/src/hooks/stage0.rs
@@ -229,7 +229,7 @@ fn init(
     unsafe {
         super::stage1::install()?;
         if on_game_load_hook_needed {
-            super::stage1::install_on_game_load()?;
+            super::stage1::install_on_game_load(&game_env)?;
         }
     }
     Ok(())

--- a/chaudloader/src/hooks/stage1.rs
+++ b/chaudloader/src/hooks/stage1.rs
@@ -47,7 +47,7 @@ static_detour! {
 }
 
 static_detour! {
-    static mmblc_OnGameLoad: unsafe extern "system" fn(
+    static mmbnlc_OnGameLoad: unsafe extern "system" fn(
         u32
     );
 }
@@ -126,7 +126,7 @@ unsafe fn on_game_load(
     game_version: u32,
     gba_state:  * mut u8,
 ) {
-    mmblc_OnGameLoad.call(game_version);
+    mmbnlc_OnGameLoad.call(game_version);
     let mod_funcs = mods::MODFUNCTIONS.get().unwrap().lock().unwrap();
     for on_game_load_functions in &mod_funcs.on_game_load_functions{
         on_game_load_functions(game_version, gba_state);
@@ -208,47 +208,37 @@ pub unsafe fn install() -> Result<(), anyhow::Error> {
 }
 
 /// Install optional on_game_laod hook into the process.
-pub unsafe fn install_on_game_load() -> Result<(), anyhow::Error> {
+pub unsafe fn install_on_game_load(game_env: &mods::GameEnv) -> Result<(), anyhow::Error> {
     unsafe {
-        let module =  windows_libloader::ModuleHandle::get(&std::env::current_exe()?.to_string_lossy())?
-                .get_base_address() as *const u8;
+        if let Some(data) = game_env.sections.text {
+            // This pattern is enough to find the function in all releases of both collections (at 0x141dde120 Vol1 / 0x143147c10 Vol2 for latest releases)
+            let on_game_load_pattern: [u8; 12] = [0x48, 0x89, 0x5c, 0x24, 0x10, 0x56, 0x48, 0x83, 0xec, 0x20, 0x8b, 0xd9];
+            if let Some(offset) = data.windows(on_game_load_pattern.len()).position(|window| window == on_game_load_pattern) {
+                let on_game_load_ptr = data.as_ptr().add(offset);
+                // Get the offset to the GBAStruct from a struction referenced in the function
+                let mov_instr_offset = 0x18;
+                let struct_rel_offset = std::ptr::read_unaligned(on_game_load_ptr.add(mov_instr_offset + 3) as * const u32) as usize;
+                let struct_offset = on_game_load_ptr.add(mov_instr_offset + 7 + struct_rel_offset) as u64;
 
-        let section = object::read::pe::PeFile64::parse(
-            std::slice::from_raw_parts(
-                module, 0x1000,
-            ))?.section_table().section(1)?;
-        
-        let (start, size) = section.pe_address_range();
-
-        let data: &[u8] = std::slice::from_raw_parts(module.add(start as usize), size as usize);
-        // This pattern is enough to find the function in all releases of both collections (at 0x141dde120 Vol1 / 143147c10 Vol2 for latest releases)
-        let on_game_load_pattern: [u8; 12] = [0x48, 0x89, 0x5c, 0x24, 0x10, 0x56, 0x48, 0x83, 0xec, 0x20, 0x8b, 0xd9];
-        if let Some(offset) = data.windows(on_game_load_pattern.len()).position(|window| window == on_game_load_pattern) {
-            let on_game_load_offset = module.add((start as usize) + offset);
-            // Get the offset to the GBAStruct from a struction referenced in the function
-            let mov_instr_offset = (start as usize) + offset + 0x18;
-            let struct_rel_offset = std::ptr::read_unaligned(module.add(mov_instr_offset + 3) as * const u32) as usize;
-            let struct_offset = module.add(mov_instr_offset + 7 + struct_rel_offset) as u64;
-
-            mmblc_OnGameLoad
-            .initialize(
-                std::mem::transmute(on_game_load_offset),
-                {
-                    move |game_version|
-                          {
-                            // let gba_state = std::mem::transmute::<u64, * mut u8>(0x80200040);
-                            // Get the gba state offset every time in case this struct moves
-                            let struct_with_gba_state = std::ptr::read_unaligned(struct_offset as * const * const u8);
-                            let gba_state = std::ptr::read_unaligned(struct_with_gba_state.add(0x3F8) as  * const * mut u8);
-                        on_game_load(game_version,
-                            gba_state,
-                        )
-                    }
-                },
-            )?
-            .enable()?;
+                mmbnlc_OnGameLoad
+                .initialize(
+                    std::mem::transmute(on_game_load_ptr),
+                    {
+                        move |game_version|
+                            {
+                                // let gba_state = std::mem::transmute::<u64, * mut u8>(0x80200040);
+                                // Get the gba state offset every time in case this struct moves
+                                let struct_with_gba_state = std::ptr::read_unaligned(struct_offset as * const * const u8);
+                                let gba_state = std::ptr::read_unaligned(struct_with_gba_state.add(0x3F8) as  * const * mut u8);
+                            on_game_load(game_version,
+                                gba_state,
+                            )
+                        }
+                    },
+                )?
+                .enable()?;
+            }
         }
     }
-
     Ok(())
 }

--- a/chaudloader/src/mods.rs
+++ b/chaudloader/src/mods.rs
@@ -49,6 +49,18 @@ impl State {
     }
 }
 
+pub struct ModFunctions {
+    pub on_game_load_functions: Vec<fn(u32, * const u8)>,
+}
+
+impl ModFunctions {
+    pub fn new() -> Self {
+        Self {
+            on_game_load_functions: Vec::new(),
+        }
+    }
+}
+
 pub struct Mod {
     pub info: Info,
     pub readme: String,
@@ -141,3 +153,4 @@ pub fn scan() -> Result<std::collections::BTreeMap<String, std::sync::Arc<Mod>>,
     }
     Ok(mods)
 }
+pub static MODFUNCTIONS: std::sync::OnceLock<std::sync::Mutex<ModFunctions>> = std::sync::OnceLock::new();


### PR DESCRIPTION
Something mods might want to do is patch the ROM / labels with new data, such as for a custom boss.
https://github.com/StraDaMa/lc2-mmbn6-mimikyu-boss-battle-mod/blob/9765903e2742e79a7d810bfcfd3d04211bffe494/LC_Mimikyu_Boss_Mod/dllmain.cpp#L12
Currently if you wanted to do this, especially for data that is only known at runtime, the approach would be to hook a BN function that is executed only once when the game is launched, such as _RandInit.
https://github.com/StraDaMa/lc2-mmbn6-mimikyu-boss-battle-mod/blob/9765903e2742e79a7d810bfcfd3d04211bffe494/LC_Mimikyu_Boss_Mod/dllmain.cpp#L418C13-L418C14

The issue with this approach is there would be a finite amount of functions to hook before the BN game main loop and a separate  hook is needed for both versions.
What this change does is check all mod DLLs for a function called `on_game_load` and executes it with a parameter for which game is loaded and a pointer to the GBAState after the game's ROM and labels are set up but before the BN game is run. This is done with a single hook chaudloader sets up for all mods to use.
So, for the Mimikyu example, all initialization could be handled like:
```
enum class MMBNGame : int {
    BN1 = 0,
    Unused,
    BN2,
    BN3_White,
    BN3_Blue,
    BN4_RedSun,
    BN4_BlueMoon,
    BN5_ProtoMan,
    BN5_Colonel,
    BN6_Gregar,
    BN6_Falzar,
};
EXTERN_DLL_EXPORT void on_game_load(MMBNGame game, GbaState* gbaState) {
    switch (game)
    {
    case MMBNGame::BN6_Gregar:
        init_mod_resources(gbaState);
        break;
    case MMBNGame::BN6_Falzar:
        init_mod_resources_f(gbaState);
        break;
    default:
        break;
    }
}
```
With no additional hooks needed by the mod.