### PR TITLE
Add Bnk file loading

### DIFF
--- a/API.md
+++ b/API.md
@@ -162,6 +162,19 @@ function Mpak:pack(): Buffer, Buffer
 
 Marshals an mpak back into .map + .mpak format.
 
+## `chaudloader.bnk`
+
+Functions for loading new bnk files.
+
+### `chaudloader.bnk.load_bnk`
+
+```lua
+function chaudloader.bnk.load_bnk(path: string)
+```
+
+Loads the bnk file from `path` after Vol1Global.bnk or Vol2Global.bnk.
+
+
 ## `chaudloader.pck`
 
 Functions for replacing playback of music/voices from pck files and loading new pck files.
@@ -216,10 +229,10 @@ Replaces attempts to play the English wem file with `id` in the game's original 
 ### `chaudloader.pck.load_pck`
 
 ```lua
-function chaudloader.pck.replace_wem(path: string)
+function chaudloader.pck.load_pck(path: string)
 ```
 
-Copies the pck files from `path` to the audio folder and loads it before the game's pck files. Any wems with IDs that match the original pck play in place of the original.
+Loads the pck file from `path` after Vol1 or Vol2.pck. Any wems with IDs that match the original pck play in place of the original.
 
 ## `chaudloader.buffer`
 

--- a/chaudloader/src/assets.rs
+++ b/chaudloader/src/assets.rs
@@ -53,6 +53,11 @@ impl Replacer {
         self.replacers.insert(path.to_path_buf(), Box::new(pack_cb));
     }
 
+    pub fn add_path(&mut self, path: &std::path::Path, dest_path: &std::path::Path) {
+        self.replacement_paths
+            .insert(path.to_path_buf(), dest_path.to_path_buf());
+    }
+
     pub fn get<'a>(
         &'a mut self,
         path: &std::path::Path,

--- a/chaudloader/src/hooks/stage0.rs
+++ b/chaudloader/src/hooks/stage0.rs
@@ -182,7 +182,7 @@ fn init(
 
     let on_game_load_hook_needed = init_mod_functions(&loaded_mods)?;
 
-    let pck_load_hook_needed = init_mod_audio()?;
+    let audio_hooks_needed = init_mod_audio()?;
 
     // We just need somewhere to keep LOADED_MODS so the DLLs don't get cleaned up, so we'll just put them here.
     std::thread_local! {
@@ -225,8 +225,9 @@ fn init(
         if on_game_load_hook_needed {
             super::stage1::install_on_game_load(&game_env)?;
         }
-        if pck_load_hook_needed {
+        if audio_hooks_needed {
             super::stage1::install_pck_load(&game_env)?;
+            super::stage1::install_bnk_load(&game_env)?;
         }
     }
     Ok(())
@@ -555,7 +556,7 @@ fn init_mod_audio() -> Result<bool, anyhow::Error> {
             .push(std::ffi::OsString::from("chaudloader.pck"));
     }
     // pcks.is_empty is checked here because pcks could either be added in the lua script or here if any wems were replaced in the lua script
-    return Ok(!mod_audio.pcks.is_empty());
+    return Ok(!mod_audio.pcks.is_empty() || !mod_audio.bnks.is_empty());
 }
 
 fn generate_chaudloader_pck(

--- a/chaudloader/src/hooks/stage1.rs
+++ b/chaudloader/src/hooks/stage1.rs
@@ -152,7 +152,7 @@ unsafe fn on_pck_load(
     let return_val = LoadFilePackage.call(sound_engine_class, pck_file_name, out_pck_id);
     match pck_wstr.to_str() {
         Some("Vol1.pck") | Some("Vol2.pck") => {
-            // Only initialize this once in case both Vol1.pck and Vol2.pck is loaded
+            // If both Vol1.pck and Vol2.pck are loaded, don't initialize again.
             static INITIALIZED: std::sync::atomic::AtomicBool =
                 std::sync::atomic::AtomicBool::new(false);
             if !INITIALIZED.fetch_or(true, std::sync::atomic::Ordering::SeqCst) {
@@ -195,7 +195,7 @@ unsafe fn on_bnk_load(
     let return_val = LoadBank.call(bnk_file_name, out_bnk_id);
     match bnk_str.as_str() {
         "Vol1Global.bnk" | "Vol2Global.bnk" => {
-            // Only initialize this once in case both Vol1Global.bnk and Vol2Global.bnk is loaded
+            // If both Vol1Global.bnk and Vol2Global.bnk are loaded, don't initialize again.
             static INITIALIZED: std::sync::atomic::AtomicBool =
                 std::sync::atomic::AtomicBool::new(false);
             if !INITIALIZED.fetch_or(true, std::sync::atomic::Ordering::SeqCst) {
@@ -343,7 +343,7 @@ pub unsafe fn install_on_game_load(game_env: &mods::GameEnv) -> Result<(), anyho
 pub unsafe fn install_pck_load(game_env: &mods::GameEnv) -> Result<(), anyhow::Error> {
     unsafe {
         if let Some(data) = game_env.sections.text {
-            // This pattern is enough to find the function in all releases of both collections (at 0x14000A5C0 Vol1 / 0x14000BD20 Vol2 for latest releases)
+            // This pattern is enough to find the function in all releases of both collections (at 0x14000A5C0 Vol1 / 0x14000BD20 Vol2 for the October 2023 releases)
             let pck_load_pattern: [u8; 24] = [
                 0x40, 0x53, 0x55, 0x56, 0x57, 0x41, 0x56, 0x48, 0x81, 0xEC, 0x80, 0x00, 0x00, 0x00,
                 0x48, 0xC7, 0x44, 0x24, 0x38, 0xFE, 0xFF, 0xFF, 0xFF, 0x48,
@@ -370,7 +370,7 @@ pub unsafe fn install_pck_load(game_env: &mods::GameEnv) -> Result<(), anyhow::E
 pub unsafe fn install_bnk_load(game_env: &mods::GameEnv) -> Result<(), anyhow::Error> {
     unsafe {
         if let Some(data) = game_env.sections.text {
-            // This pattern is enough to find the function in all releases of both collections (at 0x141CC27E0 Vol1 / 0x14302C310 Vol2 for latest releases)
+            // This pattern is enough to find the function in all releases of both collections (at 0x141CC27E0 Vol1 / 0x14302C310 Vol2 for the October 2023 releases)
             let bnk_load_pattern: [u8; 32] = [
                 0x48, 0x89, 0x5C, 0x24, 0x08, 0x48, 0x89, 0x74, 0x24, 0x10, 0x48, 0x89, 0x7C, 0x24,
                 0x18, 0x55, 0x48, 0x8D, 0x6C, 0x24, 0xA9, 0x48, 0x81, 0xEC, 0xE0, 0x00, 0x00, 0x00,

--- a/chaudloader/src/mods.rs
+++ b/chaudloader/src/mods.rs
@@ -68,6 +68,7 @@ pub struct WemFile {
 
 pub struct ModAudioFiles {
     pub pcks: Vec<std::ffi::OsString>,
+    pub bnks: Vec<std::ffi::OsString>,
     pub wems: std::collections::HashMap<u32, WemFile>,
 }
 
@@ -75,6 +76,7 @@ impl ModAudioFiles {
     pub fn new() -> Self {
         Self {
             pcks: Vec::new(),
+            bnks: Vec::new(),
             wems: std::collections::HashMap::new(),
         }
     }

--- a/chaudloader/src/mods/lua/lib/chaudloader.rs
+++ b/chaudloader/src/mods/lua/lib/chaudloader.rs
@@ -1,3 +1,4 @@
+mod bnk;
 mod buffer;
 mod exedat;
 mod modfiles;
@@ -67,6 +68,7 @@ pub fn new<'a>(
     table.set("msg", msg::new(lua)?)?;
     table.set("modfiles", modfiles::new(lua, &mod_path)?)?;
     table.set("pck", pck::new(lua, &mod_path)?)?;
+    table.set("bnk", bnk::new(lua, &mod_path)?)?;
 
     if info.r#unsafe {
         table.set("unsafe", r#unsafe::new(lua)?)?;

--- a/chaudloader/src/mods/lua/lib/chaudloader/bnk.rs
+++ b/chaudloader/src/mods/lua/lib/chaudloader/bnk.rs
@@ -22,7 +22,7 @@ pub fn new<'a>(
                 }
 
                 let base_filename = bnk_path.file_name().unwrap().to_str().unwrap();
-                const INVALID_BNK_NAMES: &[&str] = &["Init.bnk","Global.bnk","Vol1Global.bnk","Vol2Global.bnk","Voice1.bnk","DLC1.bnk","DLC2.bnk","EXE1.bnk","EXE2.bnk","EXE3.bnk","EXE4.bnk","EXE5.bnk","EXE6.bnk"];
+                const INVALID_BNK_NAMES: &[&str] = &["Init.bnk","Global.bnk","Vol1Global.bnk","Vol2Global.bnk","Voice1.bnk","DLC1.bnk","DLC2.bnk","EXE1.bnk","EXE2.bnk","EXE3.bnk","EXE4.bnk","EXE5.bnk","EXE6.bnk", "chaudloader.bnk"];
                 if INVALID_BNK_NAMES.contains(&base_filename) {
                     return Err(anyhow::anyhow!("cannot use the names: Init.bnk, Global.bnk, Vol1Global.bnk, Vol2Global.bnk, Voice1.bnk, DLC1.bnk, DLC2.bnk, EXE1.bnk, EXE2.bnk, EXE3.bnk, EXE4.bnk, EXE5.bnk, or EXE6.bnk").into_lua_err());
                 }

--- a/chaudloader/src/mods/lua/lib/chaudloader/bnk.rs
+++ b/chaudloader/src/mods/lua/lib/chaudloader/bnk.rs
@@ -1,0 +1,50 @@
+use crate::{assets, mods, path};
+use mlua::ExternalError;
+
+pub fn new<'a>(
+    lua: &'a mlua::Lua,
+    mod_path: &std::path::Path,
+) -> Result<mlua::Value<'a>, mlua::Error> {
+    let table = lua.create_table()?;
+
+    table.set(
+        "load_bnk",
+        lua.create_function({
+            let mod_path = mod_path.to_path_buf();
+            move |_, (path,): (String,)| {
+                let path = path::ensure_safe(std::path::Path::new(&path))
+                .ok_or_else(|| anyhow::anyhow!("cannot read files outside of mod directory"))
+                .map_err(|e| e.into_lua_err())?;
+
+                let bnk_path = mod_path.join(&path);
+                if !bnk_path.exists() {
+                    return Err(anyhow::anyhow!("{} does not exist", bnk_path.display()).into_lua_err());
+                }
+
+                let base_filename = bnk_path.file_name().unwrap().to_str().unwrap();
+                const INVALID_BNK_NAMES: &[&str] = &["Init.bnk","Global.bnk","Vol1Global.bnk","Vol2Global.bnk","Voice1.bnk","DLC1.bnk","DLC2.bnk","EXE1.bnk","EXE2.bnk","EXE3.bnk","EXE4.bnk","EXE5.bnk","EXE6.bnk"];
+                if INVALID_BNK_NAMES.contains(&base_filename) {
+                    return Err(anyhow::anyhow!("cannot use the names: Init.bnk, Global.bnk, Vol1Global.bnk, Vol2Global.bnk, Voice1.bnk, DLC1.bnk, DLC2.bnk, EXE1.bnk, EXE2.bnk, EXE3.bnk, EXE4.bnk, EXE5.bnk, or EXE6.bnk").into_lua_err());
+                }
+                else {
+                    let mut mod_audio = mods::MODAUDIOFILES.get().unwrap().lock().unwrap();
+                    // Check if a bnk with this file name is already being loaded because the bnk load function only takes the base file name.
+                    let base_filename_osstr = std::ffi::OsString::from(base_filename);
+                    if mod_audio.bnks.contains(&base_filename_osstr) {
+                        return Err(anyhow::anyhow!("a bnk file named {} is already being loaded", base_filename).into_lua_err());
+                    } else {
+                        // The game will only try to load bnk files from the audio folder.
+                        // Use the asset replacer to reroute it to the mod's folder.
+                        let dst_bnk_path = std::path::PathBuf::from("..\\exe\\audio").join(&base_filename);
+                        let mut assets_replacer = assets::REPLACER.get().unwrap().lock().unwrap();
+                        assets_replacer.add_path(&dst_bnk_path, &bnk_path);
+                        mod_audio.bnks.push(base_filename_osstr);
+                        return Ok(());
+                    }
+                }
+            }
+        })?,
+    )?;
+
+    Ok(mlua::Value::Table(table))
+}

--- a/chaudloader/src/mods/lua/lib/chaudloader/pck.rs
+++ b/chaudloader/src/mods/lua/lib/chaudloader/pck.rs
@@ -12,37 +12,33 @@ pub fn new<'a>(
         lua.create_function({
             let mod_path = mod_path.to_path_buf();
             move |_, (path,): (String,)| {
-                match path.as_str() {
-                    "Vol1.pck" | "Vol2.pck" | "DLC1.pck" | "DLC2.pck" | "chaudloader.pck" => {
-                        return Err(anyhow::anyhow!("cannot use the names: Vol1.pck, Vol2.pck, DLC1.pck, DLC2.pck, or chaudloader.pck").into_lua_err());
-                    },
-                    _ => {
-                        let path = path::ensure_safe(std::path::Path::new(&path))
-                            .ok_or_else(|| anyhow::anyhow!("cannot read files outside of mod directory"))
-                            .map_err(|e| e.into_lua_err())?;
+                let path = path::ensure_safe(std::path::Path::new(&path))
+                .ok_or_else(|| anyhow::anyhow!("cannot read files outside of mod directory"))
+                .map_err(|e| e.into_lua_err())?;
 
-                        let pck_path = mod_path.join(&path);
-                        if !pck_path.exists() {
-                            return Err(anyhow::anyhow!("{} does not exist", pck_path.display()).into_lua_err());
-                        }
-                        let mut mod_audio = mods::MODAUDIOFILES.get().unwrap().lock().unwrap();
-                        // Check if a pck with this file name is already being loaded because the pck load function only takes the base file name.
-                        let base_filename = pck_path.file_name().unwrap().to_os_string();
-                        if mod_audio.pcks.contains(&base_filename) {
-                            return Err(anyhow::anyhow!("a pck file named {} is already being loaded", base_filename.to_str().unwrap()).into_lua_err());
-                        } else {
-                            // The game will only try to load pck files from the audio folder.
-                            // Use the asset replacer to reroute it to the mod's folder.
-                            let dst_pck_path = std::path::PathBuf::from("..\\exe\\audio").join(&base_filename);
-                            let mut assets_replacer = assets::REPLACER.get().unwrap().lock().unwrap();
-                            assets_replacer.add(
-                                &dst_pck_path,
-                                move |writer| {
-                                    writer.write_all(std::fs::read(&pck_path)?.as_slice())
-                                });
-                            mod_audio.pcks.push(base_filename);
-                            return Ok(());
-                        }
+                let pck_path = mod_path.join(&path);
+                if !pck_path.exists() {
+                    return Err(anyhow::anyhow!("{} does not exist", pck_path.display()).into_lua_err());
+                }
+
+                const INVALID_PCK_NAMES: &[&str] = &["Vol1.pck", "Vol2.pck", "DLC1.pck", "DLC2.pck", "chaudloader.pck"];
+                let base_filename = pck_path.file_name().unwrap().to_str().unwrap();
+                if INVALID_PCK_NAMES.contains(&base_filename){
+                    return Err(anyhow::anyhow!("cannot use the names: Vol1.pck, Vol2.pck, DLC1.pck, DLC2.pck, or chaudloader.pck").into_lua_err());
+                } else {
+                    let mut mod_audio = mods::MODAUDIOFILES.get().unwrap().lock().unwrap();
+                    let base_filename_osstr = std::ffi::OsString::from(base_filename);
+                    // Check if a pck with this file name is already being loaded because the pck load function only takes the base file name.
+                    if mod_audio.pcks.contains(&base_filename_osstr) {
+                        return Err(anyhow::anyhow!("a pck file named {} is already being loaded", base_filename).into_lua_err());
+                    } else {
+                        // The game will only try to load pck files from the audio folder.
+                        // Use the asset replacer to reroute it to the mod's folder.
+                        let dst_pck_path = std::path::PathBuf::from("..\\exe\\audio").join(&base_filename);
+                        let mut assets_replacer = assets::REPLACER.get().unwrap().lock().unwrap();
+                        assets_replacer.add_path(&dst_pck_path, &pck_path);
+                        mod_audio.pcks.push(base_filename_osstr);
+                        return Ok(());
                     }
                 }
             }


### PR DESCRIPTION
This adds a new lua method for loading a user generated Bnk file for music modding.  The bnk is loaded after `Vol1Global.bnk` or `Vol2Global.bnk`
The new function is `chaudloader.bck.load_bck` and is used like:
```lua
chaudloader.bnk.load_bnk("audio/bn6_mod.bnk")
```
This also adds a new function to the replacer to replace with an existing file instead of having to create a file in the temporary directory to replace with.
The pck file loading function has also been changed to use the new replacer function.

This also prints the result of the `LoadPackageFile` and `LoadBank` functions for mod pcks and bnks to the console so errors in file loading could be more easily diagnosed.