### PR TITLE
updated assets.rs, now dats can work with / or \ to read or write files

### DIFF
--- a/chaudloader/src/assets/exedat.rs
+++ b/chaudloader/src/assets/exedat.rs
@@ -37,13 +37,13 @@ impl Overlay {
         let filecheck = self.base.get(path);
 
         match filecheck {
-            Ok(_) => return path.into(),
+            Ok(_) => path.into(),
             Err(_) => {
                 if path.contains("/") {
                     return path.replace("/", "\\");
                 }
 
-                return path.replace("\\", "/");
+                path.replace("\\", "/")
             }
         }
     }

--- a/chaudloader/src/assets/exedat.rs
+++ b/chaudloader/src/assets/exedat.rs
@@ -1,7 +1,5 @@
 use std::io::{Read, Write};
 
-use zip::{read::ZipFile, result::ZipError};
-
 pub struct Reader {
     zr: zip::ZipArchive<Box<dyn super::ReadSeek + Send>>,
 }
@@ -35,53 +33,45 @@ impl Overlay {
             overlaid_files: std::collections::HashMap::new(),
         }
     }
-    fn normalizePath<'a>(&'a mut self,path: &'a str)->String {
-        let filecheck=self.base.get(path);
-        
-        match  filecheck{
-            Ok(ZipFile)=>return path.to_string(),
-            ZipError=>{
-           
-                if path.contains("/"){
-                   return path.replace("/", "\\")
+    fn correct_path(&mut self, path: &str) -> String {
+        let filecheck = self.base.get(path);
+
+        match filecheck {
+            Ok(_) => return path.into(),
+            Err(_) => {
+                if path.contains("/") {
+                    return path.replace("/", "\\");
                 }
-              
-                   return path.replace("\\", "/")
-             
-              
-          
 
+                return path.replace("\\", "/");
             }
-
         }
-
     }
 
     pub fn read<'a>(
         &'a mut self,
         path: &str,
     ) -> Result<std::borrow::Cow<'a, [u8]>, std::io::Error> {
-        let normalPath=self.normalizePath(path);
-       
-        if let Some(contents) = self.overlaid_files.get(normalPath.as_str()) {
-         
+        let correctpath = self.correct_path(path);
+
+        if let Some(contents) = self.overlaid_files.get(correctpath.as_str()) {
             return Ok(std::borrow::Cow::Borrowed(&contents));
         }
-        let mut zf = self.base.get(normalPath.as_str())?;
+        let mut zf = self.base.get(correctpath.as_str())?;
         let mut buf = vec![];
         zf.read_to_end(&mut buf)?;
         Ok(std::borrow::Cow::Owned(buf))
     }
 
     pub fn write<'a>(&'a mut self, path: &str, contents: Vec<u8>) -> Result<(), std::io::Error> {
-        let normalPath=self.normalizePath(path);
-        if self.base.get(normalPath.as_str())?.is_dir() {
+        let correctpath = self.correct_path(path);
+        if self.base.get(correctpath.as_str())?.is_dir() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "cannot replace directory",
             ));
         }
-        self.overlaid_files.insert(normalPath, contents);
+        self.overlaid_files.insert(correctpath, contents);
         Ok(())
     }
 


### PR DESCRIPTION
Some dats like RKB have different compression to set the path of the files inside. They sometimes use / (forward slash) or \ (backward slash) to describe the path. You have to go inside with hxd to figure out which path it is. 
![image](https://github.com/user-attachments/assets/65836273-6a02-4d3d-bdff-b7d7daca76d8)
![image](https://github.com/user-attachments/assets/593bacd2-2e0f-4617-a24c-12a3d9142d14)

If you put the incorrect path, then when you write or read a file, chaudloader will fail because the current zip crate it uses will just check if it's valid file with the current path.
![image](https://github.com/user-attachments/assets/58423f21-a237-44e0-901a-bef16fb7c7c6)

So I updated exedat to check both by normalizing the path to the correct one if the file is valid.  So users don't need to check which slash and can use whatever slashes they want. Below is some working I used to test with chaudloader's current lua  interrupter on 4/9/2025.
```
local rkb = chaudloader.ExeDat("rkb.dat")
local sprite=chaudloader.modfiles.read_file("helm0000_B_BM.dds")
--helm0000_B_BM
local shader=chaudloader.modfiles.read_file("ps_skin.fxc")
rkb:write_file("exe/data/rkb/texture/helm0000_B_BM.dds",sprite)
rkb:read_file("exe/data/rkb/texture/helm0000_B_BM.dds")
rkb:write_file("exe/ps_skin.fxc",shader)
rkb:read_file("exe/ps_skin.fxc")
local rkb = chaudloader.ExeDat("rkb.dat")
local sprite=chaudloader.modfiles.read_file("helm0000_B_BM.dds")
--helm0000_B_BM
local shader=chaudloader.modfiles.read_file("ps_skin.fxc")
rkb:read_file("exe\\data\\rkb\\texture\\helm0000_B_BM.dds")
rkb:write_file("exe\\data\\rkb\\texture\\helm0000_B_BM.dds",sprite)
rkb:read_file("exe\\ps_skin.fxc")
rkb:write_file("exe\\ps_skin.fxc",shader)
```



