### PR TITLE
added support for symlinks in mods folder

### DIFF
--- a/chaudloader/src/mods.rs
+++ b/chaudloader/src/mods.rs
@@ -121,7 +121,7 @@ pub fn scan() -> Result<std::collections::BTreeMap<String, std::sync::Arc<Mod>>,
     let mut mods = std::collections::BTreeMap::new();
     for entry in std::fs::read_dir("mods")? {
         let entry = entry?;
-        if !entry.file_type()?.is_dir() {
+        if !(entry.file_type()?.is_dir() || entry.file_type()?.is_symlink()) {
             continue;
         }
 


### PR DESCRIPTION
Booted up the collection after a long hiatus and noticed half the mods weren't being recognized, namely the mods that work for both versions which I used symlinks to save a bit of storage. 

Added a check for symlinks in addition to the existing check for directory and after building it works as intended.